### PR TITLE
Child view controllers and main thread.

### DIFF
--- a/CDZQRScanningViewController.m
+++ b/CDZQRScanningViewController.m
@@ -33,6 +33,7 @@ static const NSTimeInterval CDZQRScanningTorchActivationDelay = 0.25;
     [super viewDidLoad];
 
     self.title = NSLocalizedString(@"Scan QR Code", nil);
+    self.view.backgroundColor = [UIColor blackColor];
 
     if (self.cancelBlock) {
         self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelItemSelected:)];


### PR DESCRIPTION
hey there,

i started using CDZQRScanningViewController because ZBarSDK was leaking hell and i fixed two bugs with this pull request:
- CDZQRScanningViewController was not usable as a child view controller with custom layout because the preview layers frame was only changed in willAnimateRotationToInterfaceOrientation. i moved the layout to viewDidLayoutSubviews.
- presenting an instance of CDZQRScanningViewController was really slow and blocked the main thread. thats why i moved the AV session initialization stuff onto a background thread. the view controller will now be presented immediately and have a black background until the camera input is available.
